### PR TITLE
🔥 Drop Node v4 support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -279,7 +279,6 @@
     "space-infix-ops": "error",
     "space-unary-ops": "error",
     "spaced-comment": "error",
-    "strict": "off",
     "switch-colon-spacing": "error",
     "symbol-description": "error",
     "template-curly-spacing": [

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "8"
 sudo: false

--- a/config/index.js
+++ b/config/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const Nconf = require('nconf'),
     path = require('path'),
     env = process.env.NODE_ENV || 'development';

--- a/errors.js
+++ b/errors.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const _ = require('lodash'),
     errors = require('ghost-ignition').errors,
     util = require('util');

--- a/lib/detector.js
+++ b/lib/detector.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const Promise = require('bluebird');
 const _ = require('lodash');
 const errors = require('../errors');

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const _ = require('lodash');
 const Relations = require('./relations');
 const errors = require('../errors');

--- a/lib/relations.js
+++ b/lib/relations.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const Promise = require('bluebird');
 const _ = require('lodash');
 const Detector = require('./detector');

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "email": "hello@ghost.org",
     "web": "https://ghost.org"
   },
+  "engine": {
+    "node": ">=6"
+  },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/TryGhost/bookshelf-relations/issues"

--- a/test/_database/MigratorConfig.js
+++ b/test/_database/MigratorConfig.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const config = require('../../config');
 const path = require('path');
 

--- a/test/_database/migrations/hooks/init/before.js
+++ b/test/_database/migrations/hooks/init/before.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const models = require('../../../models');
 
 module.exports = function (options) {

--- a/test/_database/migrations/init/1-tables.js
+++ b/test/_database/migrations/init/1-tables.js
@@ -1,5 +1,3 @@
-'use strict';
-
 exports.up = function up(options) {
     let connection = options.connection;
     let schema = connection.schema;

--- a/test/_database/migrations/init/2-fixtures.js
+++ b/test/_database/migrations/init/2-fixtures.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const Promise = require('bluebird');
 const models = require('../../models');
 const testUtils = require('../../../utils');

--- a/test/_database/models/authors.js
+++ b/test/_database/models/authors.js
@@ -1,5 +1,3 @@
-'use strict';
-
 module.exports = function (bookshelf) {
     bookshelf.plugin('registry');
 

--- a/test/_database/models/custom_fields.js
+++ b/test/_database/models/custom_fields.js
@@ -1,5 +1,3 @@
-'use strict';
-
 module.exports = function (bookshelf) {
     bookshelf.plugin('registry');
 

--- a/test/_database/models/index.js
+++ b/test/_database/models/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const _ = require('lodash');
 const Bookshelf = require('bookshelf');
 

--- a/test/_database/models/news.js
+++ b/test/_database/models/news.js
@@ -1,5 +1,3 @@
-'use strict';
-
 module.exports = function (bookshelf) {
     bookshelf.plugin('registry');
 

--- a/test/_database/models/posts.js
+++ b/test/_database/models/posts.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const _ = require('lodash');
 const Promise = require('bluebird');
 require('should');

--- a/test/_database/models/tags.js
+++ b/test/_database/models/tags.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const _ = require('lodash');
 
 module.exports = function (bookshelf) {

--- a/test/integration/belongsto_spec.js
+++ b/test/integration/belongsto_spec.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const _ = require('lodash');
 const models = require('../_database/models');
 const testUtils = require('../utils');

--- a/test/integration/belongstomany_spec.js
+++ b/test/integration/belongstomany_spec.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const _ = require('lodash');
 const models = require('../_database/models');
 const testUtils = require('../utils');

--- a/test/integration/hasmany_spec.js
+++ b/test/integration/hasmany_spec.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const _ = require('lodash');
 const models = require('../_database/models');
 const testUtils = require('../utils');

--- a/test/integration/hasone_spec.js
+++ b/test/integration/hasone_spec.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const _ = require('lodash');
 const models = require('../_database/models');
 const testUtils = require('../utils');

--- a/test/integration/mixed_spec.js
+++ b/test/integration/mixed_spec.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const _ = require('lodash');
 const models = require('../_database/models');
 const testUtils = require('../utils');

--- a/test/perf/perf_spec.js
+++ b/test/perf/perf_spec.js
@@ -1,5 +1,3 @@
-'use strict';
-
 process.env.NODE_ENV = 'testing-mysql';
 
 const _ = require('lodash');

--- a/test/unit/plugin_spec.js
+++ b/test/unit/plugin_spec.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const sinon = require('sinon');
 const _ = require('lodash');
 const Bookshelf = require('bookshelf');

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,3 @@
-'use strict';
-
 if (!process.env.NODE_ENV) {
     process.env.NODE_ENV = 'testing';
 }


### PR DESCRIPTION
no issue

- https://github.com/nodejs/Release
- disable running Node v4 tests in travis
- added engine to package.json `>=6`
- removed '`use strict`
- removed "strict" from eslint