### PR TITLE
Added super class initialize method call

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -3,6 +3,8 @@ const Relations = require('./relations');
 const errors = require('../errors');
 
 module.exports = function relationsPlugin(bookshelf, pluginOptions) {
+    const modelPrototype = bookshelf.Model.prototype;
+
     if (!bookshelf.manager) {
         bookshelf.manager = new Relations(bookshelf);
     }
@@ -237,6 +239,8 @@ module.exports = function relationsPlugin(bookshelf, pluginOptions) {
                     pluginOptions: pluginOpts
                 }, options);
             });
+
+            return modelPrototype.initialize.apply(this, arguments);
         }
     });
 


### PR DESCRIPTION
no issue

As recommended in Bookshelf documentation https://bookshelfjs.org/api.html#Model-instance-initialize it is recommended to call extended call after finishing initialization. 

Method provided in documentaion:  `this.constructor.__super__.initialize.apply(this, arguments)`, didn't work, so reverted to calling `initialize.apply` on the prototype. 

Tested this change with functional test suite in Ghost, and it passed.