### PR TITLE
🐛 Fixed insertion of incorrect relations for empty targets

### DIFF
--- a/lib/detector.js
+++ b/lib/detector.js
@@ -212,6 +212,10 @@ class Detector {
         let results = [];
 
         return Promise.each(newTargets, (properties) => {
+            if (_.isEmpty(properties)) {
+                return Promise.resolve();
+            }
+
             let existingTarget = existingTargets.findWhere({id: properties.id});
             let model = Target.forge(_.pick(properties, 'id'));
 

--- a/test/integration/belongstomany_spec.js
+++ b/test/integration/belongstomany_spec.js
@@ -324,11 +324,11 @@ describe('[Integration] BelongsToMany: Posts/Tags', function () {
                     },
                     expect: function (result) {
                         result.get('title').should.eql(testUtils.fixtures.getAll().posts[1].title);
-                        result.related('tags').length.should.eql(1);
+                        result.related('tags').length.should.eql(0);
 
                         return testUtils.database.getConnection()('posts_tags')
                             .then(function (result) {
-                                result.length.should.eql(1);
+                                result.length.should.eql(0);
                             })
                             .then(function () {
                                 return testUtils.database.getConnection()('tags');


### PR DESCRIPTION
closes #6

- Fixed the case where relation contained an array of empty objects and existing object from the db was inserted as a relation instead