### PR TITLE
✨ Added ability to keep related hasMany records when destroying parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.4.0 - 2020-01-05
+
+- Adds per-relationship config allowing opt-out of default child record deletion for `hasMany` relationships
+
 ### 1.0.0 - 2019-02-03
 
 Refactoring how we hook into Bookshelf. Major release was required, because

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ or
 |---|---|---|---|
 |autoHook|Boolean|true|The plugin takes over everything for you and hooks into the Bookshelf workflow.
 |allowedOptions|Array|-|An array of allowed model options the plugin passes on when executing Bookshelf queries.
-|unsetRelations|Boolean|true|The plugin will unset the relations after they are detected (e.g. `model.unset('tags')`). If you are disabling "autoHook", you manually need to unset the relations. 
+|unsetRelations|Boolean|true|The plugin will unset the relations after they are detected (e.g. `model.unset('tags')`). If you are disabling "autoHook", you manually need to unset the relations.
 |extendChanged|String|-|Define a variable name and Bookshelf-relations will store the information which relations were changed.|
 |attachPreviousRelations|Boolean|false|An option to attach previous relations. Bookshelf-relations attaches this information as `_previousRelations` on the target parent model.|
 |hooks|Object|-|<ul><li>**belongsToMany**: Hook into the process of updating belongsToMany relationships. </ul> <br><br> **Example**: ```hooks: {belongsToMany: {after: Function, beforeRelationCreation: Function}}```
@@ -33,7 +33,7 @@ Take a look [at the plugin configuration in Ghost](https://github.com/TryGhost/G
 
 ## Automatic
 
-The plugin will automatically deal with relationships upserts.
+The plugin will automatically deal with relationships upserts and cascading deletions through hasMany relationships.
 It's required to register your relationships in Bookshelf before you can use bookshelf-relations, see [this example](https://github.com/TryGhost/Ghost/blob/2.21.0/core/server/models/post.js#L502).
 
 1. Register the plugin.
@@ -48,6 +48,19 @@ It's required to register your relationships in Bookshelf before you can use boo
     bookshelf.Model.extend({
         relationships: ['tags', 'news']
     }, {...});
+```
+
+To opt-out of automatic child record deletion for `hasMany` relationships it's possible to define per-relationship config:
+
+```js
+    bookshelf.Model.extend({
+        relationships: ['tags', 'news', 'events'],
+        relationshipConfig: {
+            events: {
+                destroyRelated: false
+            }
+        }
+    });
 ```
 
 ## Manual

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -28,12 +28,17 @@ const unset = (model) => {
  * @param {Object} options
  */
 const getRelations = (model, options = {}) => {
+    const defaultRelationshipConfig = {
+        destroyRelated: true
+    };
+
     let relations = {};
 
     // NOTE: `.relationships` must be configured in the project where bookshelf-relations is used. It's an
     //       indicator which relations a resource uses.
     model.relationships.forEach((key) => {
         if (model.get(key) || options.event === 'destroying') {
+            const relationshipConfig = Object.assign({}, defaultRelationshipConfig, _.get(model.relationshipConfig, key, {}));
             const value = model.related(key);
             const relation = (model[key] instanceof Function && (typeof value === 'object' || Array.isArray(value))) ? model[key](model) : null;
             const type = relation ? relation.relatedData.type : null;
@@ -54,6 +59,11 @@ const getRelations = (model, options = {}) => {
             }
 
             if (options.event === 'destroying') {
+                // keep related records if configured to do so
+                if (relationshipConfig.destroyRelated === false) {
+                    return;
+                }
+
                 if (['belongsToMany', 'hasMany'].indexOf(type) !== -1) {
                     relations[type][key] = [];
                 } else {
@@ -331,7 +341,8 @@ module.exports = function relationsPlugin(bookshelf, pluginOptions) {
              * We have to update relations before the resource get's destroyed, otherwise we
              * loose all it's data (including the `id`).
              *
-             * Bookshelf relations will automatically destroy relations if you destroy the parent.
+             * Bookshelf relations will automatically destroy relations if you destroy the parent unless
+             * explicitly configured not to destroy related for the particular relationship
              */
             if (event === 'destroying') {
                 // CASE: Trigger bookshelf event.

--- a/lib/relations.js
+++ b/lib/relations.js
@@ -40,8 +40,6 @@ class Relations {
 
             // NOTE: Bookshelf provides us the "type" based on what you configure on your project e.g. `return this.hasMany`.
             let type = relation ? relation.relatedData.type : null;
-            let method = 'set' + type.charAt(0).toUpperCase() + type.slice(1);
-            let setter = this[method];
 
             if (!type) {
                 throw new errors.BookshelfRelationsError({
@@ -52,6 +50,9 @@ class Relations {
                     }
                 });
             }
+
+            let method = 'set' + type.charAt(0).toUpperCase() + type.slice(1);
+            let setter = this[method];
 
             promises.push(() => {
                 debug(key, method);

--- a/test/_database/migrations/init/1-tables.js
+++ b/test/_database/migrations/init/1-tables.js
@@ -28,5 +28,10 @@ exports.up = function up(options) {
         table.string('value', 255).nullable(true);
         table.integer('post_id').unsigned().nullable(false).references('posts.id');
         table.unique(['key', 'post_id']);
+    }).createTable('events', function (table) {
+        table.increments('id').primary().nullable(false);
+        table.string('type', 100).nullable(false);
+        // indexed but not referenced so parent can be deleted but these records kept
+        table.integer('post_id').unsigned().nullable(false).index();
     });
 };

--- a/test/_database/migrations/init/2-fixtures.js
+++ b/test/_database/migrations/init/2-fixtures.js
@@ -36,12 +36,23 @@ exports.up = function up() {
             author: {
                 name: 'Mozart'
             }
+        },
+        {
+            title: 'Third Post',
+            author: {
+                id: 1
+            },
+            events: [{
+                type: 'Created'
+            }, {
+                type: 'Destroyed'
+            }]
         }
     ];
 
     return Promise.each(posts, function (post) {
         return models.Post.add(post).then(function (result) {
-            testUtils.fixtures.add('posts', result.toJSON({withRelated: ['tags', 'news', 'customFields', 'author']}));
+            testUtils.fixtures.add('posts', result.toJSON({withRelated: ['tags', 'news', 'customFields', 'author', 'events']}));
         });
     });
 };

--- a/test/_database/models/events.js
+++ b/test/_database/models/events.js
@@ -1,0 +1,19 @@
+module.exports = function (bookshelf) {
+    let Event = bookshelf.Model.extend({
+        tableName: 'events',
+        requireFetch: false,
+
+        post: function () {
+            return this.belongsTo('Post', 'post_id');
+        }
+    });
+
+    let Events = bookshelf.Collection.extend({
+        model: Event
+    });
+
+    return {
+        Event: bookshelf.model('Event', Event),
+        Events: bookshelf.model('Events', Events)
+    };
+};

--- a/test/_database/models/index.js
+++ b/test/_database/models/index.js
@@ -4,7 +4,7 @@ const Bookshelf = require('bookshelf');
 exports.init = function (connection) {
     let bookshelf = Bookshelf(connection);
 
-    ['posts', 'tags', 'news', 'custom_fields', 'authors'].forEach((table) => {
+    ['posts', 'tags', 'news', 'custom_fields', 'authors', 'events'].forEach((table) => {
         const Model = require('./' + table);
         _.extend(exports, Model(bookshelf));
     });

--- a/test/_database/models/posts.js
+++ b/test/_database/models/posts.js
@@ -30,7 +30,13 @@ module.exports = function (bookshelf) {
     let Post = bookshelf.Model.extend({
         tableName: 'posts',
 
-        relationships: ['tags', 'news', 'custom_fields', 'author'],
+        relationships: ['tags', 'news', 'custom_fields', 'author', 'events'],
+
+        relationshipConfig: {
+            events: {
+                destroyRelated: false
+            }
+        },
 
         initialize: function () {
             bookshelf.Model.prototype.initialize.call(this);
@@ -54,6 +60,10 @@ module.exports = function (bookshelf) {
 
         author: function () {
             return this.belongsTo('Author', 'author_id');
+        },
+
+        events: function () {
+            return this.hasMany('Events', 'post_id');
         }
     }, {
         add: function (data, options) {

--- a/test/integration/belongsto_spec.js
+++ b/test/integration/belongsto_spec.js
@@ -14,7 +14,7 @@ describe('[Integration] BelongsTo: Posts/Author', function () {
                 method: 'fetchAll',
                 options: {withRelated: ['author']},
                 expectSuccess: (posts) => {
-                    posts.length.should.eql(2);
+                    posts.length.should.eql(3);
                     posts.models[0].related('author').toJSON().name
                         .should.eql(testUtils.fixtures.getAll().posts[0].author.name);
                     posts.models[1].related('author').toJSON().name

--- a/test/integration/belongstomany_spec.js
+++ b/test/integration/belongstomany_spec.js
@@ -14,7 +14,7 @@ describe('[Integration] BelongsToMany: Posts/Tags', function () {
                 method: 'fetchAll',
                 options: {withRelated: ['tags']},
                 expectSuccess: (posts) => {
-                    posts.length.should.eql(2);
+                    posts.length.should.eql(3);
                     posts.models[0].related('tags').length.should.eql(0);
                     posts.models[1].related('tags').length.should.eql(2);
                 }

--- a/test/integration/hasmany_spec.js
+++ b/test/integration/hasmany_spec.js
@@ -1,6 +1,6 @@
 const testUtils = require('../utils');
 
-describe('[Integration] HasMany: Posts/CustomFields', function () {
+describe('[Integration] HasMany: Posts/CustomFields+Events', function () {
     beforeEach(function () {
         return testUtils.database.reset()
             .then(function () {
@@ -12,11 +12,12 @@ describe('[Integration] HasMany: Posts/CustomFields', function () {
         it('existing', function () {
             return testUtils.testPostModel({
                 method: 'fetchAll',
-                options: {withRelated: ['custom_fields']},
+                options: {withRelated: ['custom_fields', 'events']},
                 expectSuccess: (posts) => {
-                    posts.length.should.eql(2);
+                    posts.length.should.eql(3);
                     posts.models[0].related('custom_fields').length.should.eql(0);
                     posts.models[1].related('custom_fields').length.should.eql(2);
+                    posts.models[2].related('events').length.should.eql(2);
                 }
             });
         });
@@ -50,6 +51,21 @@ describe('[Integration] HasMany: Posts/CustomFields', function () {
                         .getConnection()('custom_fields').where('post_id', 1)
                         .then((result) => {
                             result.length.should.eql(0);
+                        });
+                }
+            });
+        });
+
+        it('existingPostWithEvents', function () {
+            return testUtils.testPostModel({
+                method: 'destroy',
+                id: 3,
+                expectSuccess: () => {
+                    // related events are not deleted
+                    return testUtils.database
+                        .getConnection()('events').where('post_id', 3)
+                        .then((queryResult) => {
+                            queryResult.length.should.eql(2);
                         });
                 }
             });

--- a/test/integration/hasone_spec.js
+++ b/test/integration/hasone_spec.js
@@ -14,7 +14,7 @@ describe('[Integration] HasOne: Posts/News', function () {
                 method: 'fetchAll',
                 options: {withRelated: ['news']},
                 expectSuccess: (posts) => {
-                    posts.length.should.eql(2);
+                    posts.length.should.eql(3);
                     posts.models[0].related('news').toJSON().should.eql({});
                     posts.models[1].related('news').toJSON().should.eql(testUtils.fixtures.getAll().posts[1].news);
 

--- a/test/integration/mixed_spec.js
+++ b/test/integration/mixed_spec.js
@@ -14,7 +14,7 @@ describe('[Integration] Mixed', function () {
                 method: 'fetchAll',
                 options: {withRelated: ['author', 'news', 'tags', 'custom_fields']},
                 expectSuccess: (posts) => {
-                    posts.length.should.eql(2);
+                    posts.length.should.eql(3);
                     posts.models[0].related('author').toJSON().should.eql(testUtils.fixtures.getAll().posts[0].author);
                     posts.models[1].related('author').toJSON().should.eql(testUtils.fixtures.getAll().posts[1].author);
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12493

Adds ability to configure each relationship in the consuming app's model, eg:

```javascript
// my-model.js

relationships: ['author', 'events'],

relationshipConfig: {
    events: {
        destroyRelated: false
    }
}
```

For now only a single config option is available - `destroyRelated: true/false` - which lets you opt out of `bookshelf-relations` default behaviour of destroying any child records when the parent is deleted.