### PR TITLE
🐛 Replaced legacy ignition package with @tryghost/errors

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -1,16 +1,14 @@
-const errors = require('ghost-ignition').errors,
-    util = require('util');
+const errors = require('@tryghost/errors');
+const merge = require('lodash/merge');
 
-function BookshelfRelationsError(options) {
-    options = options || {};
-
-    options.errorType = 'BookshelfRelationsError';
-    options.level = 'critical';
-
-    errors.IgnitionError.call(this, options);
+class BookshelfRelationsError extends errors.InternalServerError {
+    constructor(options) {
+        super(merge({
+            errorType: 'BookshelfRelationsError',
+            level: 'critical'
+        }, options));
+    }
 }
-
-util.inherits(BookshelfRelationsError, errors.IgnitionError);
 
 module.exports = errors;
 module.exports.BookshelfRelationsError = BookshelfRelationsError;

--- a/lib/relations.js
+++ b/lib/relations.js
@@ -1,7 +1,7 @@
 const Promise = require('bluebird');
 const _ = require('lodash');
 const Detector = require('./detector');
-const debug = require('ghost-ignition').debug('relations');
+const debug = require('@tryghost/debug')('relations');
 const errors = require('../errors');
 
 /**
@@ -64,7 +64,7 @@ class Relations {
                     relation: relation,
                     pluginOptions: pluginOptions
                 }, opts).catch((err) => {
-                    if (errors.utils.isIgnitionError(err) || (_.isArray(err) && errors.utils.isIgnitionError(err[0]))) {
+                    if (errors.utils.isGhostError(err) || (_.isArray(err) && errors.utils.isGhostError(err[0]))) {
                         throw err;
                     }
 

--- a/package.json
+++ b/package.json
@@ -60,8 +60,9 @@
     "sqlite3": "5.0.2"
   },
   "dependencies": {
+    "@tryghost/debug": "^0.1.13",
+    "@tryghost/errors": "^1.2.3",
     "bluebird": "^3.7.2",
-    "ghost-ignition": "^4.6.2",
     "lodash": "^4.17.21"
   },
   "peerDependencies": {

--- a/test/_database/models/tags.js
+++ b/test/_database/models/tags.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const errors = require('@tryghost/errors');
 
 module.exports = function (bookshelf) {
     let Tag = bookshelf.Model.extend({
@@ -14,6 +15,10 @@ module.exports = function (bookshelf) {
                         model.unset(key);
                     }
                 });
+
+                if (model.get('slug').length === 0) {
+                    throw new errors.ValidationError({message: 'Slug should not be empty'});
+                }
             });
         }
     });

--- a/test/integration/belongstomany_spec.js
+++ b/test/integration/belongstomany_spec.js
@@ -79,6 +79,27 @@ describe('[Integration] BelongsToMany: Posts/Tags', function () {
             });
         });
 
+        it('throws ValidationErrors', function () {
+            return testUtils.testPostModel({
+                method: 'add',
+                values: {
+                    title: 'test-post-no-tags',
+                    author: {name: 'Tomas'},
+                    tags: [
+                        {
+                            id: testUtils.fixtures.getAll().posts[1].tags[1].id,
+                            slug: ''
+                        }
+                    ]
+                },
+                expectError: (err) => {
+                    err.message.should.match(/slug/gi);
+                    err.errorType.should.eql('ValidationError');
+                    err.statusCode.should.eql(422);
+                }
+            });
+        });
+
         it('withTagForeignKey', function () {
             return testUtils.testPostModel({
                 method: 'add',

--- a/test/integration/hasmany_spec.js
+++ b/test/integration/hasmany_spec.js
@@ -220,6 +220,9 @@ describe('[Integration] HasMany: Posts/CustomFields+Events', function () {
                     ]
                 },
                 expectError: (result) => {
+                    result.errorType.should.eql('BookshelfRelationsError');
+                    result.statusCode.should.eql(500);
+                    result.message.should.match(/nested/gi);
                     result.stack.should.match(/unique/gi);
 
                     return testUtils.database

--- a/test/integration/hasone_spec.js
+++ b/test/integration/hasone_spec.js
@@ -48,7 +48,7 @@ describe('[Integration] HasOne: Posts/News', function () {
         });
 
         it('existing post without news', function () {
-            require('ghost-ignition').debug('test')('begin');
+            require('@tryghost/debug')('test')('begin');
             return testUtils.testPostModel({
                 method: 'destroy',
                 id: 1,

--- a/yarn.lock
+++ b/yarn.lock
@@ -310,6 +310,14 @@
   dependencies:
     long-timeout "^0.1.1"
 
+"@tryghost/debug@^0.1.13":
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/@tryghost/debug/-/debug-0.1.13.tgz#daf23fb9caedadfb919d3444faf9c84ed549beae"
+  integrity sha512-B5/fIvee1OqxIvB1gEZRqrjeN/hHbIFmmklqLm1I3yRBWyothStVnkaGm8taIoumgIluHv6h2BsYiFKIWQx65Q==
+  dependencies:
+    "@tryghost/root-utils" "^0.3.11"
+    debug "^4.3.1"
+
 "@tryghost/elasticsearch-bunyan@0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@tryghost/elasticsearch-bunyan/-/elasticsearch-bunyan-0.1.1.tgz#5a36d81dd020825dd563b1357ae6c249580c46f5"
@@ -317,10 +325,26 @@
   dependencies:
     "@elastic/elasticsearch" "^7.10.0"
 
+"@tryghost/errors@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@tryghost/errors/-/errors-1.2.3.tgz#dccfcd09e175e4f0e437039a2653119f84b41e70"
+  integrity sha512-6vd5s2tKX4uQoKjwyP7rICPVY3jj9balc5XLcmwQjUm4yuRAL9AAcpbf1O4AwNN1gs/cN+Wknxjk/LeeIvGbGA==
+  dependencies:
+    lodash "^4.17.21"
+    uuid "^8.3.2"
+
 "@tryghost/root-utils@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@tryghost/root-utils/-/root-utils-0.1.0.tgz#7578cb5e57953316fef58edd43a152a86b719a8f"
   integrity sha512-zy3PSviwytjvjdMso86RYZLE2I4e2yL/s83fIEf/g17C8V8hsCcgE83cFOpCw3ISWDFX3Qi0IX9kI3or2pfGLg==
+  dependencies:
+    caller "^1.0.1"
+    find-root "^1.1.0"
+
+"@tryghost/root-utils@^0.3.11":
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/@tryghost/root-utils/-/root-utils-0.3.11.tgz#4c3a045c89c75301435b1d1db1946072b3ee3adf"
+  integrity sha512-1q01HsaqQSpFPVcq7tqkIUXa/L1P7yXNGbGJCeZ/IyfrSd/OdgQTluwz0BYzJc1mBP+5lIumqARr+XdbE/ZbAQ==
   dependencies:
     caller "^1.0.1"
     find-root "^1.1.0"
@@ -1660,7 +1684,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-ghost-ignition@4.6.3, ghost-ignition@^4.6.2:
+ghost-ignition@4.6.3:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/ghost-ignition/-/ghost-ignition-4.6.3.tgz#eea33bbd84e4e26096f9b7c8838f972acdab7533"
   integrity sha512-F9Kms91NG7miRH8FdmvHvWGt9crVHaKYap3gFrGekCi0TTpssN6duGi0NERSqAcf+7gC7QXT3BP/yCWwBr3fqw==
@@ -4045,7 +4069,7 @@ util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-uuid@8.3.2:
+uuid@8.3.2, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1188

- The ValidationErrors were not rethrown when they were thrown during validation of relations
- To extend on that, all newer Ghost errors from the tryghost/errors package were not rethrown
- Cause: newer ValidationError class doesn't extend IgnitionError anymore, causing 'isIgnitionError' to return false.
- BookshelfRelationsError now extends InternalServerError (GhostError) instead of IgnitionError
- Updated checks to rethrow all GhostErrors, including older IgnitionErrors
- Added a test and some new assertions
- Also updated debug calls to the new debug package