### PR TITLE
Switched to MySQL 8 for testing in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: mirromutth/mysql-action@v1.1
         if: matrix.env.DB == 'mysql'
         with:
-          mysql version: '5.7'
+          mysql version: '8.0'
           mysql database: 'bookshelf_relations_testing'
           mysql root password: 'root'
 


### PR DESCRIPTION
- we no longer support MySQL 5 so we shouldn't run tests on it