### PR TITLE
Added support for model specific hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,32 @@ or
 | editRelations           | Boolean | true    | If `false` value is passed in the plugin will not edit the properties of related models unless specified otherwise on model-level `relationshipConfig` through `editable` flag.                         |
 | extendChanged           | String  | -       | Define a variable name and Bookshelf-relations will store the information which relations were changed.                                                                                                 |
 | attachPreviousRelations | Boolean | false   | An option to attach previous relations. Bookshelf-relations attaches this information as `_previousRelations` on the target parent model.                                                               |
-| hooks                   | Object  | -       | <ul><li>**belongsToMany**: Hook into the process of updating belongsToMany relationships. </ul> <br><br> **Example**: ```hooks: {belongsToMany: {after: Function, beforeRelationCreation: Function}}``` |
+| hooks                   | Object  | -       | <ul><li>**belongsToMany**: Hook into the process of updating belongsToMany relationships. </ul> <br><br> **Example**: ```hooks: {belongsToMany: {after: Function, before: Function}}``` |
 
 Take a look [at the plugin configuration in Ghost](https://github.com/TryGhost/Ghost/blob/2.21.0/core/server/models/base/index.js#L52).
+
+## Hooks
+
+Hooks can be defined globally on the plugin options as described above, or they can be defined on a model by model basis.
+A model hook will replace a global hook if present - only one of them will run.
+
+Hook should have a structure like so: 
+
+```js
+hooks: {
+    belongsToMany: {
+        before() {},
+        after() {}
+    }
+}
+```
+
+The hooks we support are:
+ - `belongsToMany`
+    - `before` / `beforeRelationCreated`
+    - `after` / `afterRelationCreated`
+
+Either name can be used but the shorter name will be preferred if both exist.
 
 ## Automatic
 

--- a/lib/relations.js
+++ b/lib/relations.js
@@ -327,11 +327,6 @@ class Relations {
                     const globalHook = getFn(pluginOptions?.hooks?.belongsToMany, name, fallbackName);
                     const modelHook = getFn(model?.hooks?.belongsToMany, name, fallbackName);
 
-                    if (modelHook && globalHook) {
-                        // eslint-disable-next-line no-console
-                        console.warn(`A ${modelHook.name} model hook was provided which clashes with the global ${globalHook.name} hook - the global hook will not run`);
-                    }
-
                     if (modelHook) {
                         return modelHook.fn.bind(model);
                     }

--- a/lib/relations.js
+++ b/lib/relations.js
@@ -312,6 +312,9 @@ class Relations {
 
                         // NOTE: listen on created target models and allow to hook into the process
                         existingTargets.on('creating', (collection, data) => {
+                            if (model.hooks && model.hooks.belongsToMany && model.hooks.belongsToMany.beforeRelationCreation) {
+                                return model.hooks.belongsToMany.beforeRelationCreation(collection, data, opts);
+                            }
                             if (_.has(pluginOptions, 'hooks.belongsToMany.beforeRelationCreation')) {
                                 return pluginOptions.hooks.belongsToMany.beforeRelationCreation(collection, data, opts);
                             }
@@ -358,6 +361,9 @@ class Relations {
                             return existingTargets.detach(targetToDetach, _.pick(opts, ['transacting']));
                         });
                     }).then(() => {
+                        if (model.hooks && model.hooks.belongsToMany && model.hooks.belongsToMany.after) {
+                            return model.hooks.belongsToMany.after(existingTargets, targets, opts);
+                        }
                         if (_.has(pluginOptions, 'hooks.belongsToMany.after')) {
                             return pluginOptions.hooks.belongsToMany.after(existingTargets, targets, opts);
                         }

--- a/lib/relations.js
+++ b/lib/relations.js
@@ -304,6 +304,45 @@ class Relations {
                     }
                 });
 
+                function getFn(obj, nameA, nameB) {
+                    if (!obj) {
+                        return null;
+                    }
+                    if (typeof obj[nameA] === 'function') {
+                        return {
+                            fn: obj[nameA],
+                            name: nameA
+                        };
+                    }
+                    if (typeof obj[nameB] === 'function') {
+                        return {
+                            fn: obj[nameB],
+                            name: nameB
+                        };
+                    }
+                    return null;
+                }
+
+                function getHook(name, fallbackName) {
+                    const globalHook = getFn(pluginOptions?.hooks?.belongsToMany, name, fallbackName);
+                    const modelHook = getFn(model?.hooks?.belongsToMany, name, fallbackName);
+
+                    if (modelHook && globalHook) {
+                        // eslint-disable-next-line no-console
+                        console.warn(`A ${modelHook.name} model hook was provided which clashes with the global ${globalHook.name} hook - the global hook will not run`);
+                    }
+
+                    if (modelHook) {
+                        return modelHook.fn.bind(model);
+                    }
+
+                    if (globalHook) {
+                        return globalHook.fn;
+                    }
+
+                    return null;
+                }
+
                 return Promise.resolve()
                     .then(function () {
                         if (!targetsToAttach.length) {
@@ -312,11 +351,9 @@ class Relations {
 
                         // NOTE: listen on created target models and allow to hook into the process
                         existingTargets.on('creating', (collection, data) => {
-                            if (model.hooks && model.hooks.belongsToMany && model.hooks.belongsToMany.beforeRelationCreation) {
-                                return model.hooks.belongsToMany.beforeRelationCreation(collection, data, opts);
-                            }
-                            if (_.has(pluginOptions, 'hooks.belongsToMany.beforeRelationCreation')) {
-                                return pluginOptions.hooks.belongsToMany.beforeRelationCreation(collection, data, opts);
+                            const hook = getHook('before', 'beforeRelationCreation');
+                            if (hook) {
+                                return hook(collection, data, opts);
                             }
                         });
 
@@ -361,11 +398,9 @@ class Relations {
                             return existingTargets.detach(targetToDetach, _.pick(opts, ['transacting']));
                         });
                     }).then(() => {
-                        if (model.hooks && model.hooks.belongsToMany && model.hooks.belongsToMany.after) {
-                            return model.hooks.belongsToMany.after(existingTargets, targets, opts);
-                        }
-                        if (_.has(pluginOptions, 'hooks.belongsToMany.after')) {
-                            return pluginOptions.hooks.belongsToMany.after(existingTargets, targets, opts);
+                        const hook = getHook('after', 'afterRelationCreated');
+                        if (hook) {
+                            return hook(existingTargets, targets, opts);
                         }
                     });
             })

--- a/test/integration/hooks_spec.js
+++ b/test/integration/hooks_spec.js
@@ -123,10 +123,17 @@ function setupModel(knex, hookConfig) {
 }
 
 describe('[Integration] Hooks: Posts/Tags', function () {
+    let authorId;
     beforeEach(function () {
         return testUtils.database.reset()
             .then(function () {
                 return testUtils.database.init();
+            })
+            .then(function () {
+                const knex = testUtils.database.getConnection();
+                return knex('authors').select('id').first().then((row) => {
+                    authorId = row.id;
+                });
             });
     });
 
@@ -143,7 +150,7 @@ describe('[Integration] Hooks: Posts/Tags', function () {
         });
 
         return result.Post.add({
-            author_id: 420,
+            author_id: authorId,
             tags: ['blah']
         }).then(() => {
             should.equal(result.globalAfterHookCalled, false);
@@ -166,7 +173,7 @@ describe('[Integration] Hooks: Posts/Tags', function () {
         });
 
         return result.Post.add({
-            author_id: 420,
+            author_id: authorId,
             tags: ['blah']
         }).then(() => {
             should.equal(result.globalAfterHookCalled, true);
@@ -189,7 +196,7 @@ describe('[Integration] Hooks: Posts/Tags', function () {
         });
 
         return result.Post.add({
-            author_id: 420,
+            author_id: authorId,
             tags: ['blah']
         }).then(() => {
             should.equal(result.globalAfterHookCalled, false);

--- a/test/integration/hooks_spec.js
+++ b/test/integration/hooks_spec.js
@@ -1,0 +1,201 @@
+const testUtils = require('../utils');
+
+const _ = require('lodash');
+const Bookshelf = require('bookshelf');
+const errors = require('@tryghost/errors');
+
+function setupModel(knex, hookConfig) {
+    const bookshelf = Bookshelf(knex);
+    const result = {
+        globalAfterHookCalled: false,
+        globalBeforeHookCalled: false,
+        modelAfterHookCalled: false,
+        modelBeforeHookCalled: false
+    };
+
+    bookshelf.plugin(require('../../lib/plugin'), {
+        editRelations: false,
+        extendChanged: '_changed',
+        hooks: {
+            belongsToMany: {
+                after: hookConfig.global.after ? function () {
+                    result.globalAfterHookCalled = true;
+                } : null,
+                beforeRelationCreation: hookConfig.global.before ? function () {
+                    result.globalBeforeHookCalled = true;
+                } : null
+            }
+        }
+    });
+
+    let Tag = bookshelf.Model.extend({
+        tableName: 'tags',
+        requireFetch: false,
+
+        initialize: function () {
+            this.on('saving', function (model) {
+                const allowedFields = ['id', 'slug'];
+
+                _.each(model.toJSON(), (value, key) => {
+                    if (allowedFields.indexOf(key) === -1) {
+                        model.unset(key);
+                    }
+                });
+
+                if (model.get('slug').length === 0) {
+                    throw new errors.ValidationError({message: 'Slug should not be empty'});
+                }
+            });
+        }
+    });
+
+    let Post = bookshelf.Model.extend({
+        tableName: 'posts',
+
+        hooks: {
+            belongsToMany: {
+                after: hookConfig.model.after ? function () {
+                    result.modelAfterHookCalled = true;
+                } : null,
+                beforeRelationCreation: hookConfig.model.before ? function () {
+                    result.modelBeforeHookCalled = true;
+                } : null
+            }
+        },
+
+        relationships: ['tags'],
+
+        relationshipConfig: {
+            tags: {
+                editable: true
+            }
+        },
+
+        initialize: function () {
+            bookshelf.Model.prototype.initialize.call(this);
+
+            this.on('updating', function (model) {
+                model._changed = _.cloneDeep(model.changed);
+            });
+        },
+
+        tags: function () {
+            return this.belongsToMany('Tag', 'posts_tags', 'post_id', 'tag_id').withPivot('sort_order').query('orderBy', 'sort_order', 'ASC');
+        }
+    }, {
+        add: function (data, options) {
+            options = options || {};
+
+            return bookshelf.transaction((transacting) => {
+                options.transacting = transacting;
+
+                let post = this.forge(data);
+                return post.save(null, options);
+            });
+        },
+
+        edit: function (data, options) {
+            return bookshelf.transaction((transacting) => {
+                let post = this.forge(_.pick(data, 'id'));
+
+                return post.fetch(_.merge({transacting: transacting}, options))
+                    .then((dbPost) => {
+                        if (!dbPost) {
+                            throw new Error('Post does not exist');
+                        }
+
+                        return dbPost.save(_.omit(data, 'id'), _.merge({transacting: transacting}, options));
+                    });
+            });
+        },
+
+        destroy: function (data) {
+            return bookshelf.transaction((transacting) => {
+                return this.forge(_.pick(data, 'id'))
+                    .destroy({transacting: transacting});
+            });
+        }
+    });
+
+    result.Tag = bookshelf.model('Tag', Tag);
+    result.Post = bookshelf.model('Post', Post);
+    return result;
+}
+
+describe('[Integration] Hooks: Posts/Tags', function () {
+    beforeEach(function () {
+        return testUtils.database.reset()
+            .then(function () {
+                return testUtils.database.init();
+            });
+    });
+
+    it('Uses the model hooks if all hooks present', function () {
+        const result = setupModel(testUtils.database.getConnection(), {
+            global: {
+                before: true,
+                after: true
+            },
+            model: {
+                before: true,
+                after: true
+            }
+        });
+
+        return result.Post.add({
+            author_id: 'fake_author_id',
+            tags: ['blah']
+        }).then(() => {
+            should.equal(result.globalAfterHookCalled, false);
+            should.equal(result.globalBeforeHookCalled, false);
+            should.equal(result.modelAfterHookCalled, true);
+            should.equal(result.modelBeforeHookCalled, true);
+        });
+    });
+
+    it('Uses the global hooks if no model hook there', function () {
+        const result = setupModel(testUtils.database.getConnection(), {
+            global: {
+                before: true,
+                after: true
+            },
+            model: {
+                before: false,
+                after: false
+            }
+        });
+
+        return result.Post.add({
+            author_id: 'fake_author_id',
+            tags: ['blah']
+        }).then(() => {
+            should.equal(result.globalAfterHookCalled, true);
+            should.equal(result.globalBeforeHookCalled, true);
+            should.equal(result.modelAfterHookCalled, false);
+            should.equal(result.modelBeforeHookCalled, false);
+        });
+    });
+
+    it('Uses the model hooks when available', function () {
+        const result = setupModel(testUtils.database.getConnection(), {
+            global: {
+                before: true,
+                after: true
+            },
+            model: {
+                before: false,
+                after: true
+            }
+        });
+
+        return result.Post.add({
+            author_id: 'fake_author_id',
+            tags: ['blah']
+        }).then(() => {
+            should.equal(result.globalAfterHookCalled, false);
+            should.equal(result.globalBeforeHookCalled, true);
+            should.equal(result.modelAfterHookCalled, true);
+            should.equal(result.modelBeforeHookCalled, false);
+        });
+    });
+});

--- a/test/integration/hooks_spec.js
+++ b/test/integration/hooks_spec.js
@@ -143,7 +143,7 @@ describe('[Integration] Hooks: Posts/Tags', function () {
         });
 
         return result.Post.add({
-            author_id: 'fake_author_id',
+            author_id: 420,
             tags: ['blah']
         }).then(() => {
             should.equal(result.globalAfterHookCalled, false);
@@ -166,7 +166,7 @@ describe('[Integration] Hooks: Posts/Tags', function () {
         });
 
         return result.Post.add({
-            author_id: 'fake_author_id',
+            author_id: 420,
             tags: ['blah']
         }).then(() => {
             should.equal(result.globalAfterHookCalled, true);
@@ -189,7 +189,7 @@ describe('[Integration] Hooks: Posts/Tags', function () {
         });
 
         return result.Post.add({
-            author_id: 'fake_author_id',
+            author_id: 420,
             tags: ['blah']
         }).then(() => {
             should.equal(result.globalAfterHookCalled, false);


### PR DESCRIPTION
refs https://github.com/TryGhost/Arch/issues/73

Up until now we have used hooks at a global level, where we intercept the plugin to add logic for particular table names. But we now have a usecase where we want to add certain logic based on properties of the model. This extends the plugin to be able to read hooks from the model. It is backwards compatible, so will continue to work as-is for existing setups.

Note that we do not use the _.has helper as this only read properties directly from the object, and not from the prototype chain, which will not work for models which would have these hooks on the prototype.