### PR TITLE
Enforce coverage in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
       - main
       - 'renovate/*'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -38,10 +41,11 @@ jobs:
       database__connection__password: root
     name: Node ${{ matrix.node }} - ${{ matrix.env.DB }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node }}
+          cache: yarn
 
       - name: Set env vars (MySQL)
         if: contains(matrix.env.DB, 'mysql')
@@ -49,5 +53,5 @@ jobs:
           echo "database__connection__host=127.0.0.1" >> $GITHUB_ENV
           echo "database__connection__port=${{ job.services.mysql.ports['3306'] }}" >> $GITHUB_ENV
 
-      - run: yarn
-      - run: yarn test
+      - run: yarn install --frozen-lockfile
+      - run: yarn test:ci

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint . --ext .js --cache",
-    "test": "mocha --exit --timeout 10000 --report lcovonly test/integration/*_spec.js test/unit/*_spec.js",
+    "test": "mocha --exit --timeout 10000 test/integration/*_spec.js test/unit/*_spec.js",
     "posttest": "yarn lint",
     "perf": "mocha --report lcovonly test/perf/*_spec.js",
-    "coverage": "nyc --reporter=lcov _mocha --exit test/integration/*_spec.js test/unit/*_spec.js",
+    "coverage": "nyc --check-coverage --lines 80 --functions 80 --branches 80 --reporter=lcov --reporter=text-summary _mocha --exit test/integration/*_spec.js test/unit/*_spec.js",
+    "test:ci": "yarn coverage && yarn lint",
     "preship": "yarn test",
     "ship": "STATUS=$(git status --porcelain); echo $STATUS; if [ -z \"$STATUS\" ]; then yarn publish && git push --follow-tags; fi"
   },


### PR DESCRIPTION
## Summary

- enforce nyc coverage thresholds for lines, functions, and branches at 80%
- add a `test:ci` script that runs coverage plus lint
- update PR CI to run the enforced coverage gate, use frozen Yarn installs, set minimal workflow permissions, cache Yarn, and pin actions by full SHA

## CI trust evidence

Baseline/final local coverage after this change:

- Lines: 93.62% (426/455)
- Functions: 98.09% (103/105)
- Branches: 80.44% (181/225)
- Statements: 93.70% (432/461)

Boundary map:

- Package API: `bookshelf.plugin('bookshelf-relations', options)` and `bookshelf.manager.updateRelations(...)` are exercised by the existing integration suite.
- Relationship behavior: belongs-to, belongs-to-many, has-one, has-many, hooks, mixed relationship updates, and destructive relation updates are covered through real Bookshelf/Knex/sqlite test flows.
- MySQL compatibility remains covered by the existing CI matrix via `NODE_ENV=testing-mysql`.
- No HTTP endpoints, browser UI, CLI commands, background jobs, or external third-party services apply to this package.

Runtime model preserved in this PR: package engines declare Node `^18.12.1 || ^20.11.1 || ^22.13.1`, and CI continues to test Node 18, 20, and 22 across sqlite3 and MySQL. Node 24 support is intentionally left to the existing draft PR because changing the public runtime contract is a separate compatibility decision.

## Validation

- `yarn test:ci`
- `yarn test`

Both commands pass locally; ESLint reports existing warnings only.

ref [GVA-840](https://linear.app/ghost/issue/GVA-840/clean-repos-bookshelf-relations)