### PR TITLE
Add Required checks pass gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,3 +55,13 @@ jobs:
 
       - run: yarn install --frozen-lockfile
       - run: yarn test:ci
+
+  required-checks-pass:
+    name: Required checks pass
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1


### PR DESCRIPTION
## Summary

- add a `Required checks pass` aggregate job to the Test Suite workflow
- use the `required-checks-pass` job id from the current Clean Repos required-check guidance
- make the aggregate job depend on the existing matrix test job so branch protection can require one stable check name

## Why

This is the Clean Repos required-check gate after the CI trust PR landed. The current ruleset has no required status check, and requiring individual matrix jobs would couple protection to Node/database matrix names.

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/test.yml'); puts 'workflow yaml ok'"`
- `git diff --check`
- `yarn test:ci` passes locally with existing ESLint warnings only

ref [GVA-840](https://linear.app/ghost/issue/GVA-840/clean-repos-bookshelf-relations)
