### PR TITLE
Remove unused deep-diff dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   },
   "devDependencies": {
     "bookshelf": "1.2.0",
-    "deep-diff": "1.0.2",
     "eslint": "8.24.0",
     "eslint-plugin-ghost": "2.15.1",
     "knex": "2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2374,11 +2374,6 @@ decompress-response@^6.0.0:
   dependencies:
     mimic-response "^3.1.0"
 
-deep-diff@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-1.0.2.tgz#afd3d1f749115be965e89c63edc7abb1506b9c26"
-  integrity sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==
-
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"


### PR DESCRIPTION
## Summary

- remove the unused `deep-diff` devDependency
- update `yarn.lock` with Yarn classic

## Unused dependency evidence

- `npx --yes knip --dependencies` reported `deep-diff` as unused.
- `rg "deep-diff|deepDiff|DeepDiff|require\\(['\"]deep-diff['\"]\\)" --glob '!node_modules/**' --glob '!coverage/**'` returns no references after removal.
- The diff only touches `package.json` and `yarn.lock`; no package manager migration, CI gate, Renovate, lint, docs, or unrelated dependency update is included.

## Retained Knip findings

Knip still reports these devDependencies, but they are retained because they are used through test/runtime paths Knip does not fully follow in this CommonJS test setup:

- `bookshelf`: required by `test/_database/models/index.js`, `test/integration/hooks_spec.js`, and `test/unit/plugin_spec.js`; also a peer dependency for this published package.
- `knex`: required by `test/utils/db.js` and `test/unit/plugin_spec.js`.
- `knex-migrator`: required by `test/utils/db.js` to initialize/reset test migrations.
- `mysql2` and `sqlite3`: loaded dynamically by Knex from `config/env/config.testing-mysql.json` and `config/env/config.testing.json` clients.
- `nconf`: required by `config/index.js`.
- `should`: installed as a global test assertion helper by `test/utils/overrides.js`.
- `sinon`: installed as a global test helper by `test/utils/overrides.js` and used by `test/unit/plugin_spec.js`.

## Validation

- `yarn install --frozen-lockfile`
- `npx --yes knip --dependencies` now reports only the retained findings above
- `yarn test:ci` passes locally with existing ESLint warnings only

ref [GVA-840](https://linear.app/ghost/issue/GVA-840/clean-repos-bookshelf-relations)