### PR TITLE
Use shared Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "@tryghost:quietJS"
+    "local>TryGhost/renovate-config"
   ]
 }


### PR DESCRIPTION
## Summary

- switch Renovate from the legacy `@tryghost:quietJS` preset to the canonical shared preset
- add the Renovate schema reference to the touched config file

## Rationale

This standardizes Renovate config across TryGhost repos and satisfies the Clean Repos Renovate config gate.

## Preset decision

- Helper command: `(cd /Users/sam/Code/cleanrepos && uv run python skills/repo-renovate-config/scripts/resolve_preset.py bookshelf-relations --verified-ci-trust high)`
- Expected preset: `default`
- Applied preset reference: `local>TryGhost/renovate-config`
- CI-trust source: live verification and repo-meta agree on `ci_trust: high`.
- Repo-meta value: `ci_trust: high`.
- Live evidence: coverage thresholds are enforced at >=80% for lines/functions/branches, CI tests Node 18/20/22 across sqlite3 and MySQL, the `required-checks-pass` job exists on `main` with the check name `Required checks pass`, and the repo ruleset requires that stable check.

## Config locations and overrides

- Previous config location: `renovate.json`.
- New config location: `renovate.json`.
- No `package.json` Renovate key existed.
- Dropped override: `@tryghost:quietJS`, replaced by the expected shared preset.
- No local `packageRules` were added: CI uses floating Node majors (`18`, `20`, `22`) rather than an exact pinned runtime, and there is no packageManager pin to protect in this Yarn classic repo.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('renovate.json', 'utf8')); JSON.parse(require('fs').readFileSync('package.json', 'utf8')); console.log('json ok')"`
- `npx --yes --package renovate renovate-config-validator renovate.json`
- `git diff --check`
- `yarn test:ci` passes locally with existing ESLint warnings only

ref [GVA-840](https://linear.app/ghost/issue/GVA-840/clean-repos-bookshelf-relations)
