### PR TITLE
Add trusted npm publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,79 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'package.json'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Preview what would be published without actually publishing'
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'push' || github.ref == 'refs/heads/main'
+
+    permissions:
+      id-token: write
+      contents: read
+
+    env:
+      FORCE_COLOR: 1
+      CI: true
+      NPM_CONFIG_PROVENANCE: true
+      NPM_CONFIG_REGISTRY: 'https://registry.npmjs.org'
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '22.14.0'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install npm and Corepack
+        run: npm install --global npm@11.6.2 corepack@0.34.6
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Determine whether to publish
+        id: pub
+        run: |
+          name=$(jq -r .name package.json)
+          version=$(jq -r .version package.json)
+          view_error=$(mktemp)
+          if published_version=$(npm view "$name@$version" version 2>"$view_error"); then
+            if [ -z "$published_version" ]; then
+              echo "npm view succeeded without returning a version for $name@$version"
+              exit 1
+            fi
+            echo "$name@$version is already published; nothing to do"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          elif grep -q 'E404' "$view_error"; then
+            echo "queueing $name@$version"
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            cat "$view_error"
+            exit 1
+          fi
+
+      - name: Publish to npm
+        if: steps.pub.outputs.publish == 'true'
+        run: pnpm publish --no-git-checks ${{ (github.event.inputs['dry-run'] == 'true' && '--dry-run') || '' }}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "coverage": "nyc --check-coverage --lines 80 --functions 80 --branches 80 --reporter=lcov --reporter=text-summary _mocha --exit test/integration/*_spec.js test/unit/*_spec.js",
     "test:ci": "pnpm coverage && pnpm lint",
     "preship": "pnpm test",
-    "ship": "STATUS=$(git status --porcelain); echo $STATUS; if [ -z \"$STATUS\" ]; then pnpm publish && git push --follow-tags; fi"
+    "ship": "pro-ship"
   },
   "files": [
     "errors.js",
@@ -47,6 +47,7 @@
     "url": "https://github.com/TryGhost/bookshelf-relations/issues"
   },
   "devDependencies": {
+    "@tryghost/pro-ship": "1.1.5",
     "bookshelf": "1.2.0",
     "eslint": "8.57.1",
     "eslint-plugin-ghost": "2.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
         specifier: 4.18.1
         version: 4.18.1
     devDependencies:
+      '@tryghost/pro-ship':
+        specifier: 1.1.5
+        version: 1.1.5
       bookshelf:
         specifier: 1.2.0
         version: 1.2.0(knex@3.3.0(mysql2@3.22.5(@types/node@26.1.1))(sqlite3@6.0.1))
@@ -1075,6 +1078,11 @@ packages:
   '@tryghost/pretty-stream@0.2.5':
     resolution: {integrity: sha512-2bc5mk+7BAOt/mrcbjTsmUQhTKqysbIDOUUThSemPVbnij6487DhaRbnYWZW2IGKfAucrEO3h6TTm3kfioKJSw==}
 
+  '@tryghost/pro-ship@1.1.5':
+    resolution: {integrity: sha512-gwd4ynAnEHkj6bx+tfkZCYaL+WlNHQQmCkAJn7Q2H0Uq+mG74i2wwxUWr+wTuyxjLg8KviMux5uwtkEQfzi1VA==}
+    engines: {node: '>=20.20.0'}
+    hasBin: true
+
   '@tryghost/promise@0.3.20':
     resolution: {integrity: sha512-afHCBoS72XabqRi7GmHdVAWC/UMsVPGlxnL/epNVp0c/C7tEn6+MgHABXNAW4wViZFhuOda3k7fk3i2K0FAZQg==}
 
@@ -1083,6 +1091,9 @@ packages:
 
   '@tryghost/root-utils@0.3.38':
     resolution: {integrity: sha512-ARn8wC6qv867lCr7BZ+IS8S/88K5go0j6HgQFhP27rKje4b40PsxH/P3rO4Ez2NzF/Do8ywFrTWHoLCSsCazXQ==}
+
+  '@tryghost/root-utils@2.3.1':
+    resolution: {integrity: sha512-1g0HskTTDJzn3CzcEWhd4aKtcmPm3IztD7cyfQQiG4QX+6gfpPOkYk7Y5gDOwTKAYtfor0nc8npSY90vvIj93A==}
 
   '@tryghost/tpl@0.1.40':
     resolution: {integrity: sha512-8w94lbNxXptRCIS8pe/IHjzgVFLxljxXx8+UQLO8NRFKraoEXthkPjAphN2MXKp1UGtj5ldh4Ye4D82bUWceOw==}
@@ -4968,6 +4979,11 @@ snapshots:
       lodash: 4.18.1
       prettyjson: 1.2.5
 
+  '@tryghost/pro-ship@1.1.5':
+    dependencies:
+      '@tryghost/root-utils': 2.3.1
+      semver: 7.8.5
+
   '@tryghost/promise@0.3.20': {}
 
   '@tryghost/request@1.0.17':
@@ -4982,6 +4998,11 @@ snapshots:
       - supports-color
 
   '@tryghost/root-utils@0.3.38':
+    dependencies:
+      caller: 1.1.0
+      find-root: 1.1.0
+
+  '@tryghost/root-utils@2.3.1':
     dependencies:
       caller: 1.1.0
       find-root: 1.1.0


### PR DESCRIPTION
## Summary

- add .github/workflows/publish.yml for npm trusted publishing through GitHub Actions OIDC
- replace the direct pnpm publish and git push ship script with pro-ship
- add @tryghost/pro-ship as a dev dependency
- add a 10 minute timeout to the publish job
- make npm view failures fail hard unless npm returns E404 for an unpublished version
- restrict manual publish dispatch so the publish job only runs from main

## Publishing classification

- Category: single public package, using the repo-npm-publishing single-public-package pattern.
- Source repository: TryGhost/bookshelf-relations, public, default branch main.
- Package: root bookshelf-relations, public on npm; current 2.8.0 is already published.
- Repository metadata: npm package and package.json both point at TryGhost/bookshelf-relations.

## Trusted publishing setup

- Workflow filename: publish.yml.
- Workflow permissions: id-token: write and contents: read.
- Registry: https://registry.npmjs.org via actions/setup-node.
- Runtime: Node 22.14.0, within this package Node 22 support range.
- Trusted publishing CLI support: installs npm 11.6.2 and corepack 0.34.6 before enabling pnpm.
- Provenance: NPM_CONFIG_PROVENANCE=true because both the GitHub repo and npm package are public.
- Publish command: pnpm publish --no-git-checks, with manual workflow_dispatch dry-run defaulting to true.
- Dispatch guard: the publish job only runs on push events or when manual dispatch uses `refs/heads/main`.
- Idempotency: the workflow checks npm view name@version, skips when the version already exists, queues only on E404, and exits nonzero for other npm errors.
- No read-only npm token is retained; install and public npm view do not require private registry access.
- Required checks terminology: workflow uses job id `required-checks-pass` with check name `Required checks pass`.

External npm setup required before publishing:

- Configure npm trusted publishing for package bookshelf-relations.
- Repository: TryGhost/bookshelf-relations.
- Workflow filename: publish.yml.
- Allowed action: npm publish.

## Current status

- Rebased onto current main after #231 merged, including the MySQL CI repair plus latest sqlite3 and lockfile maintenance updates.
- Ready for CI recheck on the updated branch.

## Validation

- `PATH=/tmp/bookshelf-relations-corepack:$PATH pnpm install --frozen-lockfile`
- JSON parse for package.json and renovate.json
- YAML parse for .github/workflows/publish.yml and .github/workflows/test.yml
- `PATH=/tmp/bookshelf-relations-corepack:$PATH pnpm pack --dry-run`
- `PATH=/tmp/bookshelf-relations-corepack:$PATH pnpm publish --dry-run --no-git-checks`
- npm version check reports bookshelf-relations@2.8.0 is already published; publish=false
- Local publish-decision shell check for existing bookshelf-relations@2.8.0 returns already published.
- Local publish-decision shell check for missing bookshelf-relations@0.0.0-codex-missing-version queues publish via E404.
- `rg` confirms no NPM_TOKEN, NPM_AUTH_TOKEN, NODE_AUTH_TOKEN, Lerna/Nx release path, or direct publish-and-git-push ship script remains outside the new workflow.
- `rm -f .eslintcache && PATH=/tmp/bookshelf-relations-corepack:$PATH pnpm test:ci` passes: 78 tests, coverage 93.62% lines / 98.09% functions / 80.44% branches, lint exits with 79 warnings and 0 errors.
- After adding the dispatch guard: YAML parse for .github/workflows/publish.yml and `git diff --check`.

ref [GVA-840](https://linear.app/ghost/issue/GVA-840/clean-repos-bookshelf-relations)
