### PR TITLE
Apply fail-closed pnpm security baseline

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
+minimumReleaseAge: 4320
+strictDepBuilds: true
+blockExoticSubdeps: true
+
 allowBuilds:
+  better-sqlite3: false
   dtrace-provider: false
-  sqlite3: true
+  sqlite3@5.1.7: true
+  sqlite3@6.0.1: true


### PR DESCRIPTION
## What changed

- set the package cooldown to 72 hours with `minimumReleaseAge: 4320`
- make unreviewed dependency build scripts fail installation with `strictDepBuilds: true`
- reject exotic transitive dependency sources with `blockExoticSubdeps: true`
- narrow the existing `sqlite3` build permission to the two exact versions in `pnpm-lock.yaml`: `5.1.7` and `6.0.1`
- preserve the `dtrace-provider` denial and explicitly deny the already-skipped transitive `better-sqlite3` build

## Why

The previous package-wide `sqlite3: true` entry allowed any future SQLite version selected by the lockfile to run lifecycle scripts. The workspace also relied on pnpm defaults for package age, unknown build handling, and exotic transitive sources.

This makes the security behavior explicit and fail-closed without granting any new build capability. A clean strict install identified `better-sqlite3@12.11.1` as an existing implicitly ignored build; recording it as `false` preserves that behavior while allowing strict frozen installs to complete.

## Impact

Both locked SQLite versions retain the native bindings required by the current dependency graph. Any new SQLite version, undeclared lifecycle script, or exotic transitive source now requires an explicit reviewed configuration change.

## Validation

- clean `pnpm@10.34.5 install --frozen-lockfile`
- `pnpm install --frozen-lockfile --prefer-offline`
- `pnpm test:ci` — 78 tests passed; coverage gates, oxlint, and oxfmt passed
- loaded both `sqlite3@5.1.7` and `sqlite3@6.0.1` native bindings and successfully queried in-memory databases
- verified no `better-sqlite3` native binding was built
- `pnpm pack --dry-run` — expected library files only

There is no separate build script for this CommonJS library; CI-parity tests and the package dry run cover the distributable path.

Refs [PLA-320](https://linear.app/ghost/issue/PLA-320/apply-the-fail-closed-pnpm-10-baseline-to-ghost-package-repositories)
